### PR TITLE
Some improvements/bugfixes

### DIFF
--- a/lib/rs/src/codegen.rs
+++ b/lib/rs/src/codegen.rs
@@ -162,7 +162,7 @@ macro_rules! strukt {
 
                 $(if let Some(ref x) = self.$fname {
                     try!(protocol.write_field_begin(transport, stringify!($fname), <$fty as ThriftTyped>::typ(), $id));
-                    try!(x.encode(protocol, transport));
+                    try!($crate::protocol::Encode::encode(x, protocol, transport));
                     try!(protocol.write_field_end(transport));
                 })*
 
@@ -189,7 +189,7 @@ macro_rules! strukt {
                     if typ == $crate::protocol::Type::Stop {
                         break;
                     } $(else if (typ, id) == (<$fty as ThriftTyped>::typ(), $id) {
-                        try!(self.$fname.decode(protocol, transport));
+                        try!($crate::protocol::Decode::decode(&mut self.$fname, protocol, transport));
                     })* else {
                         try!(protocol.skip(transport, typ));
                     }

--- a/lib/rs/src/codegen.rs
+++ b/lib/rs/src/codegen.rs
@@ -86,7 +86,8 @@ macro_rules! service_processor_methods {
             // TODO: Further investigate this unwrap.
             let result = self.$fname.$mname($(args.$aname.unwrap()),*);
             try!($crate::protocol::helpers::send(prot, transport, MNAME,
-                                                 $crate::protocol::MessageType::Reply, &result));
+                                                 $crate::protocol::MessageType::Reply, &result,
+                                                 id));
 
             Ok(())
         })*
@@ -126,7 +127,8 @@ macro_rules! service_client_methods {
             let mut args = $iname::default();
             $(args.$aname = Some($aname);)*
             try!($crate::protocol::helpers::send(&mut self.protocol, &mut self.transport,
-                                                 MNAME, $crate::protocol::MessageType::Call, &mut args));
+                                                 MNAME, $crate::protocol::MessageType::Call, &mut args,
+                                                 0));
 
             let mut result = $oname::default();
             try!($crate::protocol::helpers::receive(&mut self.protocol, &mut self.transport,

--- a/lib/rs/src/codegen.rs
+++ b/lib/rs/src/codegen.rs
@@ -77,6 +77,7 @@ macro_rules! service_processor {
 macro_rules! service_processor_error_enum {
     ($senname:ident = []) => {};
     ($senname:ident = [$($sevname:ident($sename:ident: $sety:ty => $seid:expr),)+]) => {
+        #[derive(Debug, Clone)]
         pub enum $senname {
             $(
                 $sevname($sety),

--- a/lib/rs/src/compiletest.rs
+++ b/lib/rs/src/compiletest.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, non_camel_case_types)]
 use std::collections::{HashSet, HashMap};
 
 strukt! {
@@ -35,7 +35,7 @@ service! {
     processor_name = SharedServiceProcessor,
     client_name = SharedServiceClient,
     service_methods = [
-        SharedServiceGetStructArgs -> SharedServiceGetStructResult = shared.get_struct(key: i32 => 1,) -> DeeplyNested => [],
+        SharedServiceGetStructArgs -> SharedServiceGetStructResult = shared.get_struct(key: i32 => 1,) -> DeeplyNested => SharedServiceGetStructError = [] (DeeplyNested),
     ],
     parent_methods = [],
     bounds = [S: SharedService,],
@@ -50,10 +50,10 @@ service! {
          ChildServiceOperationArgs -> ChildServiceOperationResult = child.operation(
              one: String => 2,
              another: i32 => 3,
-         ) -> Operation => [],
+         ) -> Operation => ChildServiceOperationError = [] (Operation),
      ],
      parent_methods = [
-        SharedServiceGetStructArgs -> SharedServiceGetStructResult = shared.get_struct(key: i32 => 1,) -> DeeplyNested => [],
+        SharedServiceGetStructArgs -> SharedServiceGetStructResult = shared.get_struct(key: i32 => 1,) -> DeeplyNested => SharedServiceGetStructError = [] (DeeplyNested),
      ],
      bounds = [S: SharedService, C: ChildService,],
      fields = [shared: S, child: C,]
@@ -72,7 +72,7 @@ service! {
     processor_name = ServiceWithExceptionProcessor,
     client_name = ServiceWithExceptionClient,
     service_methods = [
-        ServiceWithExceptionOperationArgs -> ServiceWithExceptionOperationResult = this.operation() -> i32 => [bad: Exception => 1,],
+        ServiceWithExceptionOperationArgs -> ServiceWithExceptionOperationResult = this.operation() -> i32 => ServiceWithExceptionOperationError = [Bad(bad: Exception => 1),] (Result<i32, ServiceWithExceptionOperationError>),
     ],
     parent_methods = [],
     bounds = [S: ServiceWithException,],

--- a/lib/rs/src/impls.rs
+++ b/lib/rs/src/impls.rs
@@ -12,6 +12,7 @@ impl ThriftTyped for i64 { fn typ() -> Type { Type::I64 } }
 impl ThriftTyped for f64 { fn typ() -> Type { Type::Double } }
 impl ThriftTyped for () { fn typ() -> Type { Type::Void } }
 impl ThriftTyped for String { fn typ() -> Type { Type::String } }
+impl ThriftTyped for Vec<u8> { fn typ() -> Type { Type::String } }
 impl<T: ThriftTyped> ThriftTyped for Vec<T> { fn typ() -> Type { Type::List } }
 impl<T: ThriftTyped> ThriftTyped for Option<T> { fn typ() -> Type { T::typ() } }
 impl<T: ThriftTyped> ThriftTyped for HashSet<T> { fn typ() -> Type { Type::Set } }
@@ -74,6 +75,14 @@ impl Encode for String {
     fn encode<P, T>(&self, protocol: &mut P, transport: &mut T) -> Result<()>
     where P: Protocol, T: Transport {
         try!(protocol.write_string(transport, self));
+        Ok(())
+    }
+}
+
+impl Encode for Vec<u8> {
+    fn encode<P, T>(&self, protocol: &mut P, transport: &mut T) -> Result<()>
+    where P: Protocol, T: Transport {
+        try!(protocol.write_binary(transport, self));
         Ok(())
     }
 }
@@ -190,6 +199,7 @@ macro_rules! prim_decode {
 prim_decode! {
     bool => read_bool, i8 => read_byte, i16 => read_i16,
     i32 => read_i32, i64 => read_i64, f64 => read_double,
-    String => read_string
+    String => read_string,
+    Vec<u8> => read_binary
 }
 

--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(optin_builtin_traits)]
 extern crate podio;
 
 #[macro_use]

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -241,9 +241,8 @@ pub mod helpers {
 
     pub fn send<W, T, P>(protocol: &mut P, transport: &mut T,
                          name: &str, _type: MessageType,
-                         args: &W) -> Result<()>
+                         args: &W, cseqid: i32) -> Result<()>
     where W: Encode, T: Transport, P: Protocol {
-        let cseqid: i32 = 0;
         try!(protocol.write_message_begin(transport, name, _type, cseqid));
         try!(args.encode(protocol, transport));
         try!(protocol.write_message_end(transport));

--- a/tutorial/rs/src/client.rs
+++ b/tutorial/rs/src/client.rs
@@ -37,7 +37,7 @@ pub fn main() {
     println!("ping()");
 
     // Add
-    println!("1 + 1 = {}", client.add(1, 1).unwrap().success.unwrap());
+    println!("1 + 1 = {}", client.add(1, 1).unwrap());
 
     // Work: divide
     let work = tutorial::Work {
@@ -48,7 +48,7 @@ pub fn main() {
     };
 
     println!("{:?}", client.calculate(1, work.clone()).unwrap());
-    let error = client.calculate(1, work).unwrap().ouch.unwrap();
+    let error = client.calculate(1, work).unwrap().err().unwrap();
     println!("Error! {:?}", error);
 
     // Work: subtract
@@ -58,9 +58,9 @@ pub fn main() {
         num2: Some(10),
         comment: None
     };
-    println!("15 - 10 = {}", client.calculate(1, work).ok().unwrap().success.unwrap());
+    println!("15 - 10 = {}", client.calculate(1, work).unwrap().unwrap());
 
-    let ss = client.getStruct(1).ok().unwrap().success.unwrap();
+    let ss = client.getStruct(1).unwrap();
     println!("Received log: {:?}", ss);
 
     println!("PASS");

--- a/tutorial/rs/src/server.rs
+++ b/tutorial/rs/src/server.rs
@@ -43,17 +43,16 @@ struct CalculatorHandler {
 }
 
 impl<'a> Calculator for &'a CalculatorHandler {
-    fn ping(&self) -> CalculatorPingResult {
+    fn ping(&self) {
         println!("ping()");
-        CalculatorPingResult { success: Some(()) }
     }
 
-    fn add(&self, n1: i32, n2: i32) -> CalculatorAddResult {
+    fn add(&self, n1: i32, n2: i32) -> i32 {
         println!("add({}, {})", n1, n2);
-        CalculatorAddResult { success: Some(n1 + n2) }
+        n1 + n2
     }
 
-    fn calculate(&self, log_id: i32, work: Work) -> CalculatorCalculateResult {
+    fn calculate(&self, log_id: i32, work: Work) -> Result<i32, CalculatorCalculateError> {
         println!("calculate({}, {:?})", log_id, work);
 
         let num1 = work.num1.unwrap();
@@ -65,13 +64,10 @@ impl<'a> Calculator for &'a CalculatorHandler {
             Operation::MULTIPLY => num1 * num2,
             Operation::DIVIDE => {
                 if num2 == 0 {
-                    return CalculatorCalculateResult {
-                        success: None,
-                        ouch: Some(InvalidOperation {
-                            what_op: work.op.map(|x| x as i32),
-                            why: Some("Cannot divide by 0".into())
-                        })
-                    };
+                    return Err(CalculatorCalculateError::Ouch(InvalidOperation {
+                        what_op: work.op.map(|x| x as i32),
+                        why: Some("Cannot divide by 0".into())
+                    }))
                 }
 
                 num1 / num2
@@ -81,19 +77,18 @@ impl<'a> Calculator for &'a CalculatorHandler {
         let ss = SharedStruct { key: Some(log_id), value: Some(val.to_string()) };
         self.log.borrow_mut().insert(log_id, ss);
 
-        CalculatorCalculateResult { success: Some(val), ouch: None }
+        Ok(val)
     }
 
-    fn zip(&self) -> CalculatorZipResult {
+    fn zip(&self) {
         println!("zip");
-        CalculatorZipResult { success: Some(()) }
     }
 }
 
 impl<'a> SharedService for &'a CalculatorHandler {
-    fn getStruct(&self, log_id: i32) -> SharedServiceGetStructResult {
+    fn getStruct(&self, log_id: i32) -> SharedStruct {
         println!("getStruct({})", log_id);
-        SharedServiceGetStructResult { success: Some(self.log.borrow()[&log_id].clone()) }
+        self.log.borrow()[&log_id].clone()
     }
 }
 

--- a/tutorial/rs/src/shared/mod.rs
+++ b/tutorial/rs/src/shared/mod.rs
@@ -24,8 +24,8 @@ service! {
   service_methods = [
     SharedServiceGetStructArgs -> SharedServiceGetStructResult = a.getStruct(
       key: i32 => 1,
-    ) -> SharedStruct => [
-    ],
+    ) -> SharedStruct => SharedServiceGetStructError = [
+    ] (SharedStruct),
   ],
   parent_methods = [
   ],

--- a/tutorial/rs/src/tutorial/mod.rs
+++ b/tutorial/rs/src/tutorial/mod.rs
@@ -29,7 +29,7 @@ strukt! {
     num1: i32 => 1,
     num2: i32 => 2,
     op: Operation => 3,
-    comment: Option<String> => 4,
+    comment: String => 4,
   }
 }
 
@@ -47,28 +47,28 @@ service! {
   client_name = CalculatorClient,
   service_methods = [
     CalculatorPingArgs -> CalculatorPingResult = a.ping(
-    ) -> () => [
-    ],
+    ) -> () => CalculatorPingError = [
+    ] (()),
     CalculatorAddArgs -> CalculatorAddResult = a.add(
       num1: i32 => 1,
       num2: i32 => 2,
-    ) -> i32 => [
-    ],
+    ) -> i32 => CalculatorAddError = [
+    ] (i32),
     CalculatorCalculateArgs -> CalculatorCalculateResult = a.calculate(
       logid: i32 => 1,
       w: Work => 2,
-    ) -> i32 => [
-      ouch: InvalidOperation => 1,
-    ],
+    ) -> i32 => CalculatorCalculateError = [
+      Ouch(ouch: InvalidOperation => 1),
+    ] (Result<i32, CalculatorCalculateError>),
     CalculatorZipArgs -> CalculatorZipResult = a.zip(
-    ) -> () => [
-    ],
+    ) -> () => CalculatorZipError = [
+    ] (()),
   ],
   parent_methods = [
     SharedServiceGetStructArgs -> SharedServiceGetStructResult = b.getStruct(
       key: i32 => 1,
-    ) -> SharedStruct => [
-    ],
+    ) -> SharedStruct => SharedServiceGetStructError = [
+    ] (SharedStruct),
   ],
   bounds = [A: Calculator, B: SharedService, ],
   fields = [a: A, b: B, ]


### PR DESCRIPTION
- UFCS qualify method calls in macro expansion. Closes #2.
- Add support for the `binary` type. Closes #1.
- Remove the unneeded OIBIT feature usage.
- Pass a remote-provided sequence ID through in responses. A Java client talking to a Rust server wouldn't work without this.
- Give service methods good return types. For methods that have no exceptions, the method directly returns whatever it does in its service definition. For methods with exceptions, an `Error` enum is created and the method returns a `Result`.
