### PR TITLE
Allow all thrift types as keys in maps and sets.

### DIFF
--- a/compiler/cpp/src/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/generate/t_rs_generator.cc
@@ -219,9 +219,9 @@ string t_rs_generator::rs_autogen_comment() {
 }
 
 string t_rs_generator::rs_imports() {
-  return string("#![allow(unused_mut, dead_code, non_snake_case)]\n") +
-          "#[allow(unused_imports)]\n" +
-          "use std::collections::{HashMap, HashSet};\n";
+  return string("#![allow(unused_mut, dead_code, non_snake_case, unused_imports)]\n") +
+          "use ::thrift::rt::OrderedFloat;\n" +
+          "use std::collections::{BTreeMap, BTreeSet};\n";
 }
 
 // Generates a type alias, translating a thrift `typedef` to a rust `type`.
@@ -358,7 +358,7 @@ void t_rs_generator::generate_service_methods(char field, t_service* tservice) {
         indent_down();
 
         indent(f_mod_) << ") -> " << render_rs_type(tfunction->get_returntype()) << " => "
-          << errname << " = [\n"; 
+          << errname << " = [\n";
 
         indent_up();
         generate_service_method_error_variants(tfunction->get_xceptions()->get_members());
@@ -450,7 +450,7 @@ string t_rs_generator::render_rs_type(t_type* type) {
     case t_base_type::TYPE_I64:
       return "i64";
     case t_base_type::TYPE_DOUBLE:
-      return "f64";
+      return "OrderedFloat<f64>";
     }
 
   } else if (type->is_enum()) {
@@ -462,11 +462,11 @@ string t_rs_generator::render_rs_type(t_type* type) {
   } else if (type->is_map()) {
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    return "HashMap<" + render_rs_type(ktype) + ", " + render_rs_type(vtype) + ">";
+    return "BTreeMap<" + render_rs_type(ktype) + ", " + render_rs_type(vtype) + ">";
 
   } else if (type->is_set()) {
     t_type* etype = ((t_set*)type)->get_elem_type();
-    return "HashSet<" + render_rs_type(etype) + ">";
+    return "BTreeSet<" + render_rs_type(etype) + ">";
 
   } else if (type->is_list()) {
     t_type* etype = ((t_list*)type)->get_elem_type();

--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -12,4 +12,5 @@ license = "MIT"
 [dependencies]
 podio = "0.1"
 log = "0"
+ordered-float = "0"
 

--- a/lib/rs/src/codegen.rs
+++ b/lib/rs/src/codegen.rs
@@ -209,7 +209,7 @@ macro_rules! service_client_methods_translate_result {
 macro_rules! strukt {
     (name = $name:ident,
      fields = { $($fname:ident: $fty:ty => $id:expr,)+ }) => {
-        #[derive(Debug, Clone, Default)]
+        #[derive(Debug, Clone, Default, Eq, PartialEq, PartialOrd, Ord)]
         pub struct $name {
             $(pub $fname: Option<$fty>,)+
         }
@@ -319,7 +319,7 @@ macro_rules! enom {
     (name = $name:ident,
      values = [$($vname:ident = $val:expr,)*],
      default = $dname:ident) => {
-        #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
         #[repr(i32)]
         pub enum $name {
             $($vname = $val),*

--- a/lib/rs/src/compiletest.rs
+++ b/lib/rs/src/compiletest.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_camel_case_types)]
-use std::collections::{HashSet, HashMap};
+use std::collections::{BTreeSet, BTreeMap};
 
 strukt! {
     name = Simple,
@@ -11,7 +11,7 @@ strukt! {
 strukt! {
     name = DeeplyNested,
     fields = {
-        nested: HashSet<Vec<Vec<Vec<Vec<i32>>>>> => 6,
+        nested: BTreeSet<Vec<Vec<Vec<Vec<i32>>>>> => 6,
     }
 }
 
@@ -20,7 +20,7 @@ strukt! {
     fields = {
         other: DeeplyNested => 2,
         another: Simple => 3,
-        map: HashMap<i32, Vec<String>> => 4,
+        map: BTreeMap<i32, Vec<String>> => 4,
     }
 }
 

--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate podio;
+extern crate ordered_float;
 
 #[macro_use]
 extern crate log;
@@ -9,6 +10,10 @@ use std::error::Error as StdError;
 pub use protocol::Protocol;
 pub use transport::Transport;
 pub use processor::Processor;
+
+pub mod rt {
+    pub use ordered_float::OrderedFloat;
+}
 
 pub mod protocol;
 pub mod transport;

--- a/tutorial/rs/Cargo.toml
+++ b/tutorial/rs/Cargo.toml
@@ -20,5 +20,5 @@ path = "src/benchmark.rs"
 [dependencies]
 bufstream = "0.1"
 
-[dependencies.thrift]
+[dependencies.terminal_thrift]
 path = "../../lib/rs"

--- a/tutorial/rs/src/benchmark.rs
+++ b/tutorial/rs/src/benchmark.rs
@@ -18,7 +18,7 @@
  */
 
 #[macro_use]
-extern crate thrift;
+extern crate terminal_thrift as thrift;
 extern crate bufstream;
 
 use std::net::TcpStream;

--- a/tutorial/rs/src/client.rs
+++ b/tutorial/rs/src/client.rs
@@ -18,7 +18,7 @@
  */
 
 #[macro_use]
-extern crate thrift;
+extern crate terminal_thrift as thrift;
 extern crate bufstream;
 
 use std::net::TcpStream;

--- a/tutorial/rs/src/server.rs
+++ b/tutorial/rs/src/server.rs
@@ -18,7 +18,7 @@
  */
 
 #[macro_use]
-extern crate thrift;
+extern crate terminal_thrift as thrift;
 extern crate bufstream;
 
 mod tutorial;

--- a/tutorial/rs/src/shared/mod.rs
+++ b/tutorial/rs/src/shared/mod.rs
@@ -4,9 +4,9 @@
 // DO NOT EDIT UNLESS YOU ARE SURE YOU KNOW WHAT YOU ARE DOING
 ///////////////////////////////////////////////////////////////
 
-#![allow(unused_mut, dead_code, non_snake_case)]
-#[allow(unused_imports)]
-use std::collections::{HashMap, HashSet};
+#![allow(unused_mut, dead_code, non_snake_case, unused_imports)]
+use ::thrift::rt::OrderedFloat;
+use std::collections::{BTreeMap, BTreeSet};
 
 
 strukt! {

--- a/tutorial/rs/src/tutorial/mod.rs
+++ b/tutorial/rs/src/tutorial/mod.rs
@@ -4,9 +4,9 @@
 // DO NOT EDIT UNLESS YOU ARE SURE YOU KNOW WHAT YOU ARE DOING
 ///////////////////////////////////////////////////////////////
 
-#![allow(unused_mut, dead_code, non_snake_case)]
-#[allow(unused_imports)]
-use std::collections::{HashMap, HashSet};
+#![allow(unused_mut, dead_code, non_snake_case, unused_imports)]
+use ::thrift::rt::OrderedFloat;
+use std::collections::{BTreeMap, BTreeSet};
 
 use shared::*;
 


### PR DESCRIPTION
This requires two changes:
    - Use OrderedFloat<f64> instead of raw f64s to define a total ordering.
    - Use BTreeMap and BTreeSet to represent set and map instead of HashMap and HashSet.
