### PR TITLE
Revert "Support optional arguments in addition to optional struct fie…

### DIFF
--- a/compiler/cpp/src/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/generate/t_rs_generator.cc
@@ -407,14 +407,8 @@ void t_rs_generator::generate_service_method_arglist(const vector<t_field*>& fie
     vector<t_field*>::const_iterator field_iter;
     for (field_iter = fields.begin(); field_iter != fields.end(); ++field_iter) {
         t_field* tfield = *field_iter;
-
-        string type = render_rs_type(tfield->get_type());
-        if (tfield->get_req() == t_field::T_OPTIONAL) {
-          type = "Option<" + type + ">";
-        }
-
         indent(f_mod_) << to_field_name(tfield->get_name())
-            << ": " << type
+            << ": " << render_rs_type(tfield->get_type())
             << " => " << tfield->get_key() << ",\n";
     }
 }


### PR DESCRIPTION
Reverts terminalcloud/thrift#8

Turns out optional arguments are ignored and treated as required by the thrift frontend. Nothing we can do about this without changing all the other language implementations.
