### PR TITLE
Implement Proxies

### DIFF
--- a/lib/rs/src/codegen.rs
+++ b/lib/rs/src/codegen.rs
@@ -50,7 +50,7 @@ macro_rules! service_processor {
 
             /// Add a `Proxy` to be used for all incoming messages.
             pub fn proxy<P>(&mut self, proxy: P)
-            where P: 'static + for<'e> $crate::proxy::Proxy<$crate::virt::VirtualEncodeObject<'e>> {
+            where P: 'static + Send + Sync + for<'e> $crate::proxy::Proxy<$crate::virt::VirtualEncodeObject<'e>> {
                 self.proxies.proxy(proxy)
             }
 

--- a/lib/rs/src/codegen.rs
+++ b/lib/rs/src/codegen.rs
@@ -36,7 +36,7 @@ macro_rules! service_processor {
      fields = [$($fname:ident: $fty:ty,)*]) => {
         pub struct $name<$($boundty: $bound),*> {
             $($fname: $fty,)*
-            _ugh: ()
+            proxies: $crate::proxy::Proxies
         }
 
         $(strukt! { name = $siname, fields = { $($saname: Option<$saty> => $said,)* } }
@@ -45,7 +45,7 @@ macro_rules! service_processor {
 
         impl<$($boundty: $bound),*> $name<$($boundty),*> {
             pub fn new($($fname: $fty),*) -> Self {
-                $name { $($fname: $fname,)* _ugh: () }
+                $name { $($fname: $fname,)* proxies: Default::default() }
             }
 
             pub fn dispatch<P: $crate::Protocol, T: $crate::Transport>(&self, prot: &mut P, transport: &mut T,
@@ -99,11 +99,15 @@ macro_rules! service_processor_methods {
     (methods = [$($iname:ident -> $oname:ident = $fname:ident.$mname:ident($($aname:ident: $aty:ty => $aid:expr,)*) -> $rty:ty => $enname:ident = [$($evname:ident($ename:ident: $ety:ty => $eid:expr),)*] ($rrty:ty),)*]) => {
         $(fn $mname<P: $crate::Protocol, T: $crate::Transport>(&self, prot: &mut P, transport: &mut T,
                                                                ty: $crate::protocol::MessageType, id: i32) -> $crate::Result<()> {
+            use $crate::proxy::Proxy;
+
             static MNAME: &'static str = stringify!($mname);
 
             let mut args = $iname::default();
             try!($crate::protocol::helpers::receive_body(prot, transport, MNAME,
                                                          &mut args, MNAME, ty, id));
+
+            self.proxies.proxy(ty, MNAME, id, &args);
 
             // TODO: Further investigate this unwrap.
             let result = self.$fname.$mname($(args.$aname.unwrap()),*);
@@ -222,7 +226,7 @@ macro_rules! strukt {
         }
 
         impl $crate::protocol::ThriftTyped for $name {
-            fn typ() -> $crate::protocol::Type { $crate::protocol::Type::Struct }
+            fn typ(&self) -> $crate::protocol::Type { $crate::protocol::Type::Struct }
         }
 
         impl $crate::protocol::Encode for $name {
@@ -236,7 +240,8 @@ macro_rules! strukt {
                 try!(protocol.write_struct_begin(transport, stringify!($name)));
 
                 $(if $crate::protocol::Encode::should_encode(&self.$fname) {
-                    try!(protocol.write_field_begin(transport, stringify!($fname), <$fty as ThriftTyped>::typ(), $id));
+                    try!(protocol.write_field_begin(transport, stringify!($fname),
+                                                    $crate::protocol::helpers::typ::<$fty>(), $id));
                     try!($crate::protocol::Encode::encode(&self.$fname, protocol, transport));
                     try!(protocol.write_field_end(transport));
                 })*
@@ -263,7 +268,7 @@ macro_rules! strukt {
 
                     if typ == $crate::protocol::Type::Stop {
                         break;
-                    } $(else if (typ, id) == (<$fty as ThriftTyped>::typ(), $id) {
+                    } $(else if (typ, id) == ($crate::protocol::helpers::typ::<$fty>(), $id) {
                         try!($crate::protocol::Decode::decode(&mut self.$fname, protocol, transport));
                     })* else {
                         try!(protocol.skip(transport, typ));
@@ -283,7 +288,7 @@ macro_rules! strukt {
         pub struct $name;
 
         impl $crate::protocol::ThriftTyped for $name {
-            fn typ() -> $crate::protocol::Type { $crate::protocol::Type::Struct }
+            fn typ(&self) -> $crate::protocol::Type { $crate::protocol::Type::Struct }
         }
 
         impl $crate::protocol::Encode for $name {
@@ -346,7 +351,7 @@ macro_rules! enom {
         }
 
         impl $crate::protocol::ThriftTyped for $name {
-            fn typ() -> $crate::protocol::Type { $crate::protocol::Type::I32 }
+            fn typ(&self) -> $crate::protocol::Type { $crate::protocol::Type::I32 }
         }
 
         impl $crate::protocol::Encode for $name {

--- a/lib/rs/src/codegen.rs
+++ b/lib/rs/src/codegen.rs
@@ -48,6 +48,12 @@ macro_rules! service_processor {
                 $name { $($fname: $fname,)* proxies: Default::default() }
             }
 
+            /// Add a `Proxy` to be used for all incoming messages.
+            pub fn proxy<P>(&mut self, proxy: P)
+            where P: 'static + for<'e> $crate::proxy::Proxy<$crate::virt::VirtualEncodeObject<'e>> {
+                self.proxies.proxy(proxy)
+            }
+
             pub fn dispatch<P: $crate::Protocol, T: $crate::Transport>(&self, prot: &mut P, transport: &mut T,
                                                                        name: &str, ty: $crate::protocol::MessageType, id: i32) -> $crate::Result<()> {
                 match name {

--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit="1024"]
 extern crate podio;
 extern crate ordered_float;
 
@@ -19,6 +20,8 @@ pub mod protocol;
 pub mod transport;
 pub mod server;
 pub mod processor;
+pub mod proxy;
+pub mod virt;
 
 #[macro_use]
 mod codegen;

--- a/lib/rs/src/mock/mod.rs
+++ b/lib/rs/src/mock/mod.rs
@@ -40,6 +40,8 @@ impl io::Read for MockTransport {
     }
 }
 
+impl Transport for MockTransport {}
+
 #[derive(Debug, Default, Clone)]
 pub struct MockProtocol {
     log: Vec<ProtocolAction>

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -413,7 +413,7 @@ impl<'a, P: ?Sized> Protocol for &'a mut P where P: Protocol {
     }
 }
 
-pub trait FromNum {
+pub trait FromNum: Sized {
     fn from_num(num: i32) -> Option<Self>;
 }
 

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -130,7 +130,7 @@ impl MessageType {
 }
 
 pub trait ThriftTyped {
-    fn typ() -> Type;
+    fn typ(&self) -> Type;
 }
 
 pub trait Encode: ThriftTyped {
@@ -223,14 +223,208 @@ pub trait Protocol {
     fn skip<T: Transport>(&mut self, transport: &mut T, type_: Type) -> Result<()>;
 }
 
+impl<'a, T: ?Sized> ThriftTyped for &'a T where T: ThriftTyped {
+    fn typ(&self) -> Type { <T as ThriftTyped>::typ(self) }
+}
+
+impl<'a, E: ?Sized> Encode for &'a E where E: Encode {
+    fn encode<P, T>(&self, protocol: &mut P, transport: &mut T) -> Result<()>
+    where P: Protocol, T: Transport {
+        <E as Encode>::encode(self, protocol, transport)
+    }
+
+    fn should_encode(&self) -> bool { <E as Encode>::should_encode(self) }
+}
+
+impl<'a, P: ?Sized> Protocol for &'a mut P where P: Protocol {
+    fn write_message_begin<T: Transport>(&mut self, transport: &mut T, name: &str,
+                           message_type: MessageType, sequence_id: i32) -> Result<()> {
+        <P as Protocol>::write_message_begin(self, transport, name, message_type, sequence_id)
+    }
+
+    fn write_message_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::write_message_end(self, transport)
+    }
+
+    fn write_struct_begin<T: Transport>(&mut self, transport: &mut T, name: &str) -> Result<()> {
+        <P as Protocol>::write_struct_begin(self, transport, name)
+    }
+
+    fn write_struct_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::write_struct_end(self, transport)
+    }
+
+    fn write_field_begin<T: Transport>(&mut self, transport: &mut T, name: &str,
+                         field_type: Type, field_id: i16) -> Result<()> {
+        <P as Protocol>::write_field_begin(self, transport, name, field_type, field_id)
+    }
+
+    fn write_field_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::write_field_end(self, transport)
+    }
+
+    fn write_field_stop<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::write_field_stop(self, transport)
+    }
+
+    fn write_map_begin<T: Transport>(&mut self, transport: &mut T, key_type: Type,
+                       value_type: Type, size: usize) -> Result<()> {
+        <P as Protocol>::write_map_begin(self, transport, key_type, value_type, size)
+    }
+
+    fn write_map_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::write_map_end(self, transport)
+    }
+
+    fn write_list_begin<T: Transport>(&mut self, transport: &mut T, elem_type: Type, size: usize) -> Result<()> {
+        <P as Protocol>::write_list_begin(self, transport, elem_type, size)
+    }
+
+    fn write_list_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::write_list_end(self, transport)
+    }
+
+    fn write_set_begin<T: Transport>(&mut self, transport: &mut T, elem_type: Type, size: usize) -> Result<()> {
+        <P as Protocol>::write_set_begin(self, transport, elem_type, size)
+    }
+
+    fn write_set_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::write_set_end(self, transport)
+    }
+
+    fn write_bool<T: Transport>(&mut self, transport: &mut T, value: bool) -> Result<()> {
+        <P as Protocol>::write_bool(self, transport, value)
+    }
+
+    fn write_byte<T: Transport>(&mut self, transport: &mut T, value: i8) -> Result<()> {
+         <P as Protocol>::write_byte(self, transport, value)
+    }
+
+    fn write_i16<T: Transport>(&mut self, transport: &mut T, value: i16) -> Result<()> {
+        <P as Protocol>::write_i16(self, transport, value)
+    }
+
+    fn write_i32<T: Transport>(&mut self, transport: &mut T, value: i32) -> Result<()> {
+        <P as Protocol>::write_i32(self, transport, value)
+    }
+
+    fn write_i64<T: Transport>(&mut self, transport: &mut T, value: i64) -> Result<()> {
+        <P as Protocol>::write_i64(self, transport, value)
+    }
+
+    fn write_double<T: Transport>(&mut self, transport: &mut T, value: f64) -> Result<()> {
+        <P as Protocol>::write_double(self, transport, value)
+    }
+
+    fn write_str<T: Transport>(&mut self, transport: &mut T, value: &str) -> Result<()> {
+        <P as Protocol>::write_str(self, transport, value)
+    }
+
+    fn write_string<T: Transport>(&mut self, transport: &mut T, value: &String) -> Result<()> {
+        <P as Protocol>::write_string(self, transport, value)
+    }
+
+    fn write_binary<T: Transport>(&mut self, transport: &mut T, value: &[u8]) -> Result<()> {
+        <P as Protocol>::write_binary(self, transport, value)
+    }
+
+    fn read_message_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(String, MessageType, i32)> {
+        <P as Protocol>::read_message_begin(self, transport)
+    }
+
+    fn read_message_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::read_message_end(self, transport)
+    }
+
+    fn read_struct_begin<T: Transport>(&mut self, transport: &mut T) -> Result<String> {
+        <P as Protocol>::read_struct_begin(self, transport)
+    }
+
+    fn read_struct_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::read_struct_end(self, transport)
+    }
+
+    fn read_field_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(String, Type, i16)> {
+        <P as Protocol>::read_field_begin(self, transport)
+    }
+
+    fn read_field_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::read_field_end(self, transport)
+    }
+
+    fn read_map_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(Type, Type, i32)> {
+        <P as Protocol>::read_map_begin(self, transport)
+    }
+
+    fn read_map_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::read_map_end(self, transport)
+    }
+
+    fn read_list_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(Type, i32)> {
+        <P as Protocol>::read_list_begin(self, transport)
+    }
+
+    fn read_list_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::read_list_end(self, transport)
+    }
+
+    fn read_set_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(Type, i32)> {
+        <P as Protocol>::read_set_begin(self, transport)
+    }
+
+    fn read_set_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        <P as Protocol>::read_set_end(self, transport)
+    }
+
+    fn read_bool<T: Transport>(&mut self, transport: &mut T) -> Result<bool> {
+        <P as Protocol>::read_bool(self, transport)
+    }
+
+    fn read_byte<T: Transport>(&mut self, transport: &mut T) -> Result<i8> {
+        <P as Protocol>::read_byte(self, transport)
+    }
+
+    fn read_i16<T: Transport>(&mut self, transport: &mut T) -> Result<i16> {
+        <P as Protocol>::read_i16(self, transport)
+    }
+
+    fn read_i32<T: Transport>(&mut self, transport: &mut T) -> Result<i32> {
+        <P as Protocol>::read_i32(self, transport)
+    }
+
+    fn read_i64<T: Transport>(&mut self, transport: &mut T) -> Result<i64> {
+        <P as Protocol>::read_i64(self, transport)
+    }
+
+    fn read_double<T: Transport>(&mut self, transport: &mut T) -> Result<f64> {
+        <P as Protocol>::read_double(self, transport)
+    }
+
+    fn read_string<T: Transport>(&mut self, transport: &mut T) -> Result<String> {
+        <P as Protocol>::read_string(self, transport)
+    }
+
+    fn read_binary<T: Transport>(&mut self, transport: &mut T) -> Result<Vec<u8>> {
+        <P as Protocol>::read_binary(self, transport)
+    }
+
+    fn skip<T: Transport>(&mut self, transport: &mut T, type_: Type) -> Result<()> {
+        <P as Protocol>::skip(self, transport, type_)
+    }
+}
+
 pub trait FromNum {
     fn from_num(num: i32) -> Option<Self>;
 }
 
 pub mod helpers {
-    use protocol::{Protocol, Type, MessageType, FromNum, Decode, Encode, Error};
+    use protocol::{ThriftTyped, Protocol, Type, MessageType, FromNum, Decode, Encode, Error};
     use transport::Transport;
     use Result;
+
+    pub fn typ<T: ThriftTyped + Default>() -> Type {
+        T::default().typ()
+    }
 
     pub fn read_enum<F, T, P>(iprot: &mut P, transport: &mut T) -> Result<F>
     where F: FromNum, T: Transport, P: Protocol {

--- a/lib/rs/src/proxy.rs
+++ b/lib/rs/src/proxy.rs
@@ -1,0 +1,47 @@
+use std::error::Error;
+
+use virt::{VirtualEncodeObject};
+use protocol::{MessageType, Encode, ProtocolFactory};
+use transport::server::{TransportServer};
+
+type VirtualProxy = for<'e> Proxy<VirtualEncodeObject<'e>>;
+
+#[derive(Default)]
+pub struct Proxies {
+    proxies: Vec<Box<VirtualProxy>>
+}
+
+impl Proxies {
+    pub fn new() -> Proxies { Proxies::default() }
+}
+
+impl<E: Encode> Proxy<E> for Proxies {
+    fn proxy(&self, mtype: MessageType, operation: &str, id: i32, message: E) {
+        for proxy in &self.proxies {
+            let message: VirtualEncodeObject = &message;
+            proxy.proxy(mtype, operation, id, message);
+        }
+    }
+}
+
+pub trait Proxy<E: Encode> {
+    fn proxy(&self, mtype: MessageType, operation: &str, id: i32, message: E);
+}
+
+pub struct SimpleProxy<PF, TS> {
+    protocol_factory: PF,
+    transport_server: TS
+}
+
+impl<E, PF, TS> Proxy<E> for SimpleProxy<PF, TS>
+where PF: ProtocolFactory, TS: TransportServer, E: Encode {
+    fn proxy(&self, mtype: MessageType, operation: &str, id: i32, message: E) {
+        let _: Result<(), Box<Error>> = (|| {
+            let mut protocol = self.protocol_factory.new_protocol();
+            let mut transport = try!(self.transport_server.accept());
+
+            Ok(try!(::protocol::helpers::send(&mut protocol, &mut transport, operation, mtype, &message, id)))
+        })();
+    }
+}
+

--- a/lib/rs/src/proxy.rs
+++ b/lib/rs/src/proxy.rs
@@ -13,6 +13,10 @@ pub struct Proxies {
 
 impl Proxies {
     pub fn new() -> Proxies { Proxies::default() }
+
+    pub fn proxy<P: for<'e> Proxy<VirtualEncodeObject<'e>> + 'static>(&mut self, proxy: P) {
+        self.proxies.push(Box::new(proxy));
+    }
 }
 
 impl<E: Encode> Proxy<E> for Proxies {
@@ -31,6 +35,17 @@ pub trait Proxy<E: Encode> {
 pub struct SimpleProxy<PF, TS> {
     protocol_factory: PF,
     transport_server: TS
+}
+
+impl<PF, TS> SimpleProxy<PF, TS> {
+    /// Create a new `SimpleProxy` that will replay messages over the given
+    /// server transports using the given protocols.
+    pub fn new(factory: PF, server: TS) -> SimpleProxy<PF, TS> {
+        SimpleProxy {
+            protocol_factory: factory,
+            transport_server: server
+        }
+    }
 }
 
 impl<E, PF, TS> Proxy<E> for SimpleProxy<PF, TS>

--- a/lib/rs/src/proxy.rs
+++ b/lib/rs/src/proxy.rs
@@ -8,13 +8,13 @@ type VirtualProxy = for<'e> Proxy<VirtualEncodeObject<'e>>;
 
 #[derive(Default)]
 pub struct Proxies {
-    proxies: Vec<Box<VirtualProxy>>
+    proxies: Vec<Box<for<'e> Proxy<VirtualEncodeObject<'e>> + Send + Sync>>
 }
 
 impl Proxies {
     pub fn new() -> Proxies { Proxies::default() }
 
-    pub fn proxy<P: for<'e> Proxy<VirtualEncodeObject<'e>> + 'static>(&mut self, proxy: P) {
+    pub fn proxy<P: for<'e> Proxy<VirtualEncodeObject<'e>> + Send + Sync + 'static>(&mut self, proxy: P) {
         self.proxies.push(Box::new(proxy));
     }
 }

--- a/lib/rs/src/transport/server/mod.rs
+++ b/lib/rs/src/transport/server/mod.rs
@@ -21,6 +21,8 @@ use std::io;
 use std::net::{TcpListener, TcpStream};
 use super::Transport;
 
+impl Transport for TcpStream {}
+
 pub trait TransportServer {
     type Transport: Transport;
 

--- a/lib/rs/src/transport/server/mod.rs
+++ b/lib/rs/src/transport/server/mod.rs
@@ -36,3 +36,11 @@ impl TransportServer for TcpListener {
         self.accept().map(|res| res.0)
     }
 }
+
+impl<F, T> TransportServer for F
+where F: Fn() -> io::Result<T>, T: Transport {
+    type Transport = T;
+
+    fn accept(&self) -> io::Result<T> { self() }
+}
+

--- a/lib/rs/src/virt.rs
+++ b/lib/rs/src/virt.rs
@@ -25,7 +25,7 @@ impl<'e> Encode for VirtualEncodeObject<'e> {
     fn encode<'p, 't, P1, T1>(&self, mut protocol: &'p mut P1, mut transport: &'t mut T1) -> Result<()>
     where P1: Protocol, T1: Transport {
         let protocol: VirtualProtocolObject<'p> = protocol;
-        self.virt_encode(protocol, &mut transport)
+        (*self).virt_encode(protocol, &mut transport)
     }
 }
 

--- a/lib/rs/src/virt.rs
+++ b/lib/rs/src/virt.rs
@@ -287,177 +287,177 @@ impl<P, T> VirtualProtocol<T> for P where P: Protocol, T: Transport {
 impl<'p> Protocol for VirtualProtocolObject<'p> {
     fn write_message_begin<T: Transport>(&mut self, transport: &mut T, name: &str,
                            message_type: MessageType, sequence_id: i32) -> Result<()> {
-        self.virt_write_message_begin(transport, name, message_type, sequence_id)
+        (*self).virt_write_message_begin(transport, name, message_type, sequence_id)
     }
 
     fn write_message_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_write_message_end(transport)
+        (*self).virt_write_message_end(transport)
     }
 
     fn write_struct_begin<T: Transport>(&mut self, transport: &mut T, name: &str) -> Result<()> {
-        self.virt_write_struct_begin(transport, name)
+        (*self).virt_write_struct_begin(transport, name)
     }
 
     fn write_struct_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_write_struct_end(transport)
+        (*self).virt_write_struct_end(transport)
     }
 
     fn write_field_begin<T: Transport>(&mut self, transport: &mut T, name: &str,
                          field_type: Type, field_id: i16) -> Result<()> {
-        self.virt_write_field_begin(transport, name, field_type, field_id)
+        (*self).virt_write_field_begin(transport, name, field_type, field_id)
     }
 
     fn write_field_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_write_field_end(transport)
+        (*self).virt_write_field_end(transport)
     }
 
     fn write_field_stop<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_write_field_stop(transport)
+        (*self).virt_write_field_stop(transport)
     }
 
     fn write_map_begin<T: Transport>(&mut self, transport: &mut T, key_type: Type,
                        value_type: Type, size: usize) -> Result<()> {
-        self.virt_write_map_begin(transport, key_type, value_type, size)
+        (*self).virt_write_map_begin(transport, key_type, value_type, size)
     }
 
     fn write_map_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_write_map_end(transport)
+        (*self).virt_write_map_end(transport)
     }
 
     fn write_list_begin<T: Transport>(&mut self, transport: &mut T, elem_type: Type, size: usize) -> Result<()> {
-        self.virt_write_list_begin(transport, elem_type, size)
+        (*self).virt_write_list_begin(transport, elem_type, size)
     }
 
     fn write_list_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_write_list_end(transport)
+        (*self).virt_write_list_end(transport)
     }
 
     fn write_set_begin<T: Transport>(&mut self, transport: &mut T, elem_type: Type, size: usize) -> Result<()> {
-        self.virt_write_set_begin(transport, elem_type, size)
+        (*self).virt_write_set_begin(transport, elem_type, size)
     }
 
     fn write_set_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_write_set_end(transport)
+        (*self).virt_write_set_end(transport)
     }
 
     fn write_bool<T: Transport>(&mut self, transport: &mut T, value: bool) -> Result<()> {
-        self.virt_write_bool(transport, value)
+        (*self).virt_write_bool(transport, value)
     }
 
     fn write_byte<T: Transport>(&mut self, transport: &mut T, value: i8) -> Result<()> {
-         self.virt_write_byte(transport, value)
+         (*self).virt_write_byte(transport, value)
     }
 
     fn write_i16<T: Transport>(&mut self, transport: &mut T, value: i16) -> Result<()> {
-        self.virt_write_i16(transport, value)
+        (*self).virt_write_i16(transport, value)
     }
 
     fn write_i32<T: Transport>(&mut self, transport: &mut T, value: i32) -> Result<()> {
-        self.virt_write_i32(transport, value)
+        (*self).virt_write_i32(transport, value)
     }
 
     fn write_i64<T: Transport>(&mut self, transport: &mut T, value: i64) -> Result<()> {
-        self.virt_write_i64(transport, value)
+        (*self).virt_write_i64(transport, value)
     }
 
     fn write_double<T: Transport>(&mut self, transport: &mut T, value: f64) -> Result<()> {
-        self.virt_write_double(transport, value)
+        (*self).virt_write_double(transport, value)
     }
 
     fn write_str<T: Transport>(&mut self, transport: &mut T, value: &str) -> Result<()> {
-        self.virt_write_str(transport, value)
+        (*self).virt_write_str(transport, value)
     }
 
     fn write_string<T: Transport>(&mut self, transport: &mut T, value: &String) -> Result<()> {
-        self.virt_write_string(transport, value)
+        (*self).virt_write_string(transport, value)
     }
 
     fn write_binary<T: Transport>(&mut self, transport: &mut T, value: &[u8]) -> Result<()> {
-        self.virt_write_binary(transport, value)
+        (*self).virt_write_binary(transport, value)
     }
 
     fn read_message_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(String, MessageType, i32)> {
-        self.virt_read_message_begin(transport)
+        (*self).virt_read_message_begin(transport)
     }
 
     fn read_message_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_read_message_end(transport)
+        (*self).virt_read_message_end(transport)
     }
 
     fn read_struct_begin<T: Transport>(&mut self, transport: &mut T) -> Result<String> {
-        self.virt_read_struct_begin(transport)
+        (*self).virt_read_struct_begin(transport)
     }
 
     fn read_struct_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_read_struct_end(transport)
+        (*self).virt_read_struct_end(transport)
     }
 
     fn read_field_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(String, Type, i16)> {
-        self.virt_read_field_begin(transport)
+        (*self).virt_read_field_begin(transport)
     }
 
     fn read_field_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_read_field_end(transport)
+        (*self).virt_read_field_end(transport)
     }
 
     fn read_map_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(Type, Type, i32)> {
-        self.virt_read_map_begin(transport)
+        (*self).virt_read_map_begin(transport)
     }
 
     fn read_map_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_read_map_end(transport)
+        (*self).virt_read_map_end(transport)
     }
 
     fn read_list_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(Type, i32)> {
-        self.virt_read_list_begin(transport)
+        (*self).virt_read_list_begin(transport)
     }
 
     fn read_list_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_read_list_end(transport)
+        (*self).virt_read_list_end(transport)
     }
 
     fn read_set_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(Type, i32)> {
-        self.virt_read_set_begin(transport)
+        (*self).virt_read_set_begin(transport)
     }
 
     fn read_set_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
-        self.virt_read_set_end(transport)
+        (*self).virt_read_set_end(transport)
     }
 
     fn read_bool<T: Transport>(&mut self, transport: &mut T) -> Result<bool> {
-        self.virt_read_bool(transport)
+        (*self).virt_read_bool(transport)
     }
 
     fn read_byte<T: Transport>(&mut self, transport: &mut T) -> Result<i8> {
-        self.virt_read_byte(transport)
+        (*self).virt_read_byte(transport)
     }
 
     fn read_i16<T: Transport>(&mut self, transport: &mut T) -> Result<i16> {
-        self.virt_read_i16(transport)
+        (*self).virt_read_i16(transport)
     }
 
     fn read_i32<T: Transport>(&mut self, transport: &mut T) -> Result<i32> {
-        self.virt_read_i32(transport)
+        (*self).virt_read_i32(transport)
     }
 
     fn read_i64<T: Transport>(&mut self, transport: &mut T) -> Result<i64> {
-        self.virt_read_i64(transport)
+        (*self).virt_read_i64(transport)
     }
 
     fn read_double<T: Transport>(&mut self, transport: &mut T) -> Result<f64> {
-        self.virt_read_double(transport)
+        (*self).virt_read_double(transport)
     }
 
     fn read_string<T: Transport>(&mut self, transport: &mut T) -> Result<String> {
-        self.virt_read_string(transport)
+        (*self).virt_read_string(transport)
     }
 
     fn read_binary<T: Transport>(&mut self, transport: &mut T) -> Result<Vec<u8>> {
-        self.virt_read_binary(transport)
+        (*self).virt_read_binary(transport)
     }
 
     fn skip<T: Transport>(&mut self, transport: &mut T, type_: Type) -> Result<()> {
-        self.virt_skip(transport, type_)
+        (*self).virt_skip(transport, type_)
     }
 }
 

--- a/lib/rs/src/virt.rs
+++ b/lib/rs/src/virt.rs
@@ -1,0 +1,473 @@
+use protocol::{ThriftTyped, Encode, Protocol, Type, MessageType};
+use transport::Transport;
+
+use {Result};
+
+pub type VirtualEncodeObject<'e> = &'e for<'p, 't> VirtualEncode<VirtualProtocolObject<'p>, &'t mut Transport>;
+pub type VirtualProtocolObject<'p> = &'p mut for<'t> VirtualProtocol<&'t mut Transport>;
+
+pub trait VirtualEncode<P, T>: ThriftTyped {
+    fn virt_encode(&self, P, T) -> Result<()>;
+
+    fn should_encode(&self) -> bool { true }
+}
+
+impl<E, P, T> VirtualEncode<P, T> for E
+where E: Encode, P: Protocol, T: Transport {
+    fn virt_encode(&self, mut protocol: P, mut transport: T) -> Result<()> {
+        self.encode(&mut protocol, &mut transport)
+    }
+
+    fn should_encode(&self) -> bool { Encode::should_encode(self) }
+}
+
+impl<'e> Encode for VirtualEncodeObject<'e> {
+    fn encode<'p, 't, P1, T1>(&self, mut protocol: &'p mut P1, mut transport: &'t mut T1) -> Result<()>
+    where P1: Protocol, T1: Transport {
+        let protocol: VirtualProtocolObject<'p> = protocol;
+        self.virt_encode(protocol, &mut transport)
+    }
+}
+
+pub trait VirtualProtocol<T> {
+    fn virt_write_message_begin(
+        &mut self,
+        transport: T,
+        name: &str,
+        message_type: MessageType,
+        sequence_id: i32
+    ) -> Result<()>;
+    fn virt_write_message_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_write_struct_begin(&mut self, transport: T, name: &str) -> Result<()>;
+    fn virt_write_struct_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_write_field_begin(
+        &mut self,
+        transport: T,
+        name: &str,
+        field_type: Type,
+        field_id: i16
+    ) -> Result<()>;
+    fn virt_write_field_end(&mut self, transport: T) -> Result<()>;
+    fn virt_write_field_stop(&mut self, transport: T) -> Result<()>;
+
+    fn virt_write_map_begin(
+        &mut self,
+        transport: T,
+        key_type: Type,
+        value_type: Type,
+        size: usize
+    ) -> Result<()>;
+    fn virt_write_map_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_write_list_begin(&mut self, transport: T, elem_type: Type, size: usize) -> Result<()>;
+    fn virt_write_list_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_write_set_begin(&mut self, transport: T, elem_type: Type, size: usize) -> Result<()>;
+    fn virt_write_set_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_write_bool(&mut self, transport: T, value: bool) -> Result<()>;
+    fn virt_write_byte(&mut self, transport: T, value: i8) -> Result<()>;
+    fn virt_write_i16(&mut self, transport: T, value: i16) -> Result<()>;
+    fn virt_write_i32(&mut self, transport: T, value: i32) -> Result<()>;
+    fn virt_write_i64(&mut self, transport: T, value: i64) -> Result<()>;
+    fn virt_write_double(&mut self, transport: T, value: f64) -> Result<()>;
+    fn virt_write_str(&mut self, transport: T, value: &str) -> Result<()>;
+    fn virt_write_string(&mut self, transport: T, value: &String) -> Result<()>;
+    fn virt_write_binary(&mut self, transport: T, value: &[u8]) -> Result<()>;
+
+    fn virt_read_message_begin(&mut self, transport: T) -> Result<(String, MessageType, i32)>;
+    fn virt_read_message_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_read_struct_begin(&mut self, transport: T) -> Result<String>;
+    fn virt_read_struct_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_read_field_begin(&mut self, transport: T) -> Result<(String, Type, i16)>;
+    fn virt_read_field_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_read_map_begin(&mut self, transport: T) -> Result<(Type, Type, i32)>;
+    fn virt_read_map_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_read_list_begin(&mut self, transport: T) -> Result<(Type, i32)>;
+    fn virt_read_list_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_read_set_begin(&mut self, transport: T) -> Result<(Type, i32)>;
+    fn virt_read_set_end(&mut self, transport: T) -> Result<()>;
+
+    fn virt_read_bool(&mut self, transport: T) -> Result<bool>;
+    fn virt_read_byte(&mut self, transport: T) -> Result<i8>;
+    fn virt_read_i16(&mut self, transport: T) -> Result<i16>;
+    fn virt_read_i32(&mut self, transport: T) -> Result<i32>;
+    fn virt_read_i64(&mut self, transport: T) -> Result<i64>;
+    fn virt_read_double(&mut self, transport: T) -> Result<f64>;
+    fn virt_read_string(&mut self, transport: T) -> Result<String>;
+    fn virt_read_binary(&mut self, transport: T) -> Result<Vec<u8>>;
+
+    fn virt_skip(&mut self, transport: T, type_: Type) -> Result<()>;
+}
+
+impl<P, T> VirtualProtocol<T> for P where P: Protocol, T: Transport {
+    fn virt_write_message_begin(&mut self, mut transport: T, name: &str,
+                           message_type: MessageType, sequence_id: i32) -> Result<()> {
+        Protocol::write_message_begin(self, &mut transport, name, message_type, sequence_id)
+    }
+
+    fn virt_write_message_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::write_message_end(self, &mut transport)
+    }
+
+    fn virt_write_struct_begin(&mut self, mut transport: T, name: &str) -> Result<()> {
+        Protocol::write_struct_begin(self, &mut transport, name)
+    }
+
+    fn virt_write_struct_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::write_struct_end(self, &mut transport)
+    }
+
+    fn virt_write_field_begin(&mut self, mut transport: T, name: &str,
+                         field_type: Type, field_id: i16) -> Result<()> {
+        Protocol::write_field_begin(self, &mut transport, name, field_type, field_id)
+    }
+
+    fn virt_write_field_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::write_field_end(self, &mut transport)
+    }
+
+    fn virt_write_field_stop(&mut self, mut transport: T) -> Result<()> {
+        Protocol::write_field_stop(self, &mut transport)
+    }
+
+    fn virt_write_map_begin(&mut self, mut transport: T, key_type: Type,
+                       value_type: Type, size: usize) -> Result<()> {
+        Protocol::write_map_begin(self, &mut transport, key_type, value_type, size)
+    }
+
+    fn virt_write_map_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::write_map_end(self, &mut transport)
+    }
+
+    fn virt_write_list_begin(&mut self, mut transport: T, elem_type: Type, size: usize) -> Result<()> {
+        Protocol::write_list_begin(self, &mut transport, elem_type, size)
+    }
+
+    fn virt_write_list_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::write_list_end(self, &mut transport)
+    }
+
+    fn virt_write_set_begin(&mut self, mut transport: T, elem_type: Type, size: usize) -> Result<()> {
+        Protocol::write_set_begin(self, &mut transport, elem_type, size)
+    }
+
+    fn virt_write_set_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::write_set_end(self, &mut transport)
+    }
+
+    fn virt_write_bool(&mut self, mut transport: T, value: bool) -> Result<()> {
+        Protocol::write_bool(self, &mut transport, value)
+    }
+
+    fn virt_write_byte(&mut self, mut transport: T, value: i8) -> Result<()> {
+         Protocol::write_byte(self, &mut transport, value)
+    }
+
+    fn virt_write_i16(&mut self, mut transport: T, value: i16) -> Result<()> {
+        Protocol::write_i16(self, &mut transport, value)
+    }
+
+    fn virt_write_i32(&mut self, mut transport: T, value: i32) -> Result<()> {
+        Protocol::write_i32(self, &mut transport, value)
+    }
+
+    fn virt_write_i64(&mut self, mut transport: T, value: i64) -> Result<()> {
+        Protocol::write_i64(self, &mut transport, value)
+    }
+
+    fn virt_write_double(&mut self, mut transport: T, value: f64) -> Result<()> {
+        Protocol::write_double(self, &mut transport, value)
+    }
+
+    fn virt_write_str(&mut self, mut transport: T, value: &str) -> Result<()> {
+        Protocol::write_str(self, &mut transport, value)
+    }
+
+    fn virt_write_string(&mut self, mut transport: T, value: &String) -> Result<()> {
+        Protocol::write_string(self, &mut transport, value)
+    }
+
+    fn virt_write_binary(&mut self, mut transport: T, value: &[u8]) -> Result<()> {
+        Protocol::write_binary(self, &mut transport, value)
+    }
+
+    fn virt_read_message_begin(&mut self, mut transport: T) -> Result<(String, MessageType, i32)> {
+        Protocol::read_message_begin(self, &mut transport)
+    }
+
+    fn virt_read_message_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::read_message_end(self, &mut transport)
+    }
+
+    fn virt_read_struct_begin(&mut self, mut transport: T) -> Result<String> {
+        Protocol::read_struct_begin(self, &mut transport)
+    }
+
+    fn virt_read_struct_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::read_struct_end(self, &mut transport)
+    }
+
+    fn virt_read_field_begin(&mut self, mut transport: T) -> Result<(String, Type, i16)> {
+        Protocol::read_field_begin(self, &mut transport)
+    }
+
+    fn virt_read_field_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::read_field_end(self, &mut transport)
+    }
+
+    fn virt_read_map_begin(&mut self, mut transport: T) -> Result<(Type, Type, i32)> {
+        Protocol::read_map_begin(self, &mut transport)
+    }
+
+    fn virt_read_map_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::read_map_end(self, &mut transport)
+    }
+
+    fn virt_read_list_begin(&mut self, mut transport: T) -> Result<(Type, i32)> {
+        Protocol::read_list_begin(self, &mut transport)
+    }
+
+    fn virt_read_list_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::read_list_end(self, &mut transport)
+    }
+
+    fn virt_read_set_begin(&mut self, mut transport: T) -> Result<(Type, i32)> {
+        Protocol::read_set_begin(self, &mut transport)
+    }
+
+    fn virt_read_set_end(&mut self, mut transport: T) -> Result<()> {
+        Protocol::read_set_end(self, &mut transport)
+    }
+
+    fn virt_read_bool(&mut self, mut transport: T) -> Result<bool> {
+        Protocol::read_bool(self, &mut transport)
+    }
+
+    fn virt_read_byte(&mut self, mut transport: T) -> Result<i8> {
+        Protocol::read_byte(self, &mut transport)
+    }
+
+    fn virt_read_i16(&mut self, mut transport: T) -> Result<i16> {
+        Protocol::read_i16(self, &mut transport)
+    }
+
+    fn virt_read_i32(&mut self, mut transport: T) -> Result<i32> {
+        Protocol::read_i32(self, &mut transport)
+    }
+
+    fn virt_read_i64(&mut self, mut transport: T) -> Result<i64> {
+        Protocol::read_i64(self, &mut transport)
+    }
+
+    fn virt_read_double(&mut self, mut transport: T) -> Result<f64> {
+        Protocol::read_double(self, &mut transport)
+    }
+
+    fn virt_read_string(&mut self, mut transport: T) -> Result<String> {
+        Protocol::read_string(self, &mut transport)
+    }
+
+    fn virt_read_binary(&mut self, mut transport: T) -> Result<Vec<u8>> {
+        Protocol::read_binary(self, &mut transport)
+    }
+
+    fn virt_skip(&mut self, mut transport: T, type_: Type) -> Result<()> {
+        Protocol::skip(self, &mut transport, type_)
+    }
+}
+
+impl<'p> Protocol for VirtualProtocolObject<'p> {
+    fn write_message_begin<T: Transport>(&mut self, transport: &mut T, name: &str,
+                           message_type: MessageType, sequence_id: i32) -> Result<()> {
+        self.virt_write_message_begin(transport, name, message_type, sequence_id)
+    }
+
+    fn write_message_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_write_message_end(transport)
+    }
+
+    fn write_struct_begin<T: Transport>(&mut self, transport: &mut T, name: &str) -> Result<()> {
+        self.virt_write_struct_begin(transport, name)
+    }
+
+    fn write_struct_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_write_struct_end(transport)
+    }
+
+    fn write_field_begin<T: Transport>(&mut self, transport: &mut T, name: &str,
+                         field_type: Type, field_id: i16) -> Result<()> {
+        self.virt_write_field_begin(transport, name, field_type, field_id)
+    }
+
+    fn write_field_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_write_field_end(transport)
+    }
+
+    fn write_field_stop<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_write_field_stop(transport)
+    }
+
+    fn write_map_begin<T: Transport>(&mut self, transport: &mut T, key_type: Type,
+                       value_type: Type, size: usize) -> Result<()> {
+        self.virt_write_map_begin(transport, key_type, value_type, size)
+    }
+
+    fn write_map_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_write_map_end(transport)
+    }
+
+    fn write_list_begin<T: Transport>(&mut self, transport: &mut T, elem_type: Type, size: usize) -> Result<()> {
+        self.virt_write_list_begin(transport, elem_type, size)
+    }
+
+    fn write_list_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_write_list_end(transport)
+    }
+
+    fn write_set_begin<T: Transport>(&mut self, transport: &mut T, elem_type: Type, size: usize) -> Result<()> {
+        self.virt_write_set_begin(transport, elem_type, size)
+    }
+
+    fn write_set_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_write_set_end(transport)
+    }
+
+    fn write_bool<T: Transport>(&mut self, transport: &mut T, value: bool) -> Result<()> {
+        self.virt_write_bool(transport, value)
+    }
+
+    fn write_byte<T: Transport>(&mut self, transport: &mut T, value: i8) -> Result<()> {
+         self.virt_write_byte(transport, value)
+    }
+
+    fn write_i16<T: Transport>(&mut self, transport: &mut T, value: i16) -> Result<()> {
+        self.virt_write_i16(transport, value)
+    }
+
+    fn write_i32<T: Transport>(&mut self, transport: &mut T, value: i32) -> Result<()> {
+        self.virt_write_i32(transport, value)
+    }
+
+    fn write_i64<T: Transport>(&mut self, transport: &mut T, value: i64) -> Result<()> {
+        self.virt_write_i64(transport, value)
+    }
+
+    fn write_double<T: Transport>(&mut self, transport: &mut T, value: f64) -> Result<()> {
+        self.virt_write_double(transport, value)
+    }
+
+    fn write_str<T: Transport>(&mut self, transport: &mut T, value: &str) -> Result<()> {
+        self.virt_write_str(transport, value)
+    }
+
+    fn write_string<T: Transport>(&mut self, transport: &mut T, value: &String) -> Result<()> {
+        self.virt_write_string(transport, value)
+    }
+
+    fn write_binary<T: Transport>(&mut self, transport: &mut T, value: &[u8]) -> Result<()> {
+        self.virt_write_binary(transport, value)
+    }
+
+    fn read_message_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(String, MessageType, i32)> {
+        self.virt_read_message_begin(transport)
+    }
+
+    fn read_message_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_read_message_end(transport)
+    }
+
+    fn read_struct_begin<T: Transport>(&mut self, transport: &mut T) -> Result<String> {
+        self.virt_read_struct_begin(transport)
+    }
+
+    fn read_struct_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_read_struct_end(transport)
+    }
+
+    fn read_field_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(String, Type, i16)> {
+        self.virt_read_field_begin(transport)
+    }
+
+    fn read_field_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_read_field_end(transport)
+    }
+
+    fn read_map_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(Type, Type, i32)> {
+        self.virt_read_map_begin(transport)
+    }
+
+    fn read_map_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_read_map_end(transport)
+    }
+
+    fn read_list_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(Type, i32)> {
+        self.virt_read_list_begin(transport)
+    }
+
+    fn read_list_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_read_list_end(transport)
+    }
+
+    fn read_set_begin<T: Transport>(&mut self, transport: &mut T) -> Result<(Type, i32)> {
+        self.virt_read_set_begin(transport)
+    }
+
+    fn read_set_end<T: Transport>(&mut self, transport: &mut T) -> Result<()> {
+        self.virt_read_set_end(transport)
+    }
+
+    fn read_bool<T: Transport>(&mut self, transport: &mut T) -> Result<bool> {
+        self.virt_read_bool(transport)
+    }
+
+    fn read_byte<T: Transport>(&mut self, transport: &mut T) -> Result<i8> {
+        self.virt_read_byte(transport)
+    }
+
+    fn read_i16<T: Transport>(&mut self, transport: &mut T) -> Result<i16> {
+        self.virt_read_i16(transport)
+    }
+
+    fn read_i32<T: Transport>(&mut self, transport: &mut T) -> Result<i32> {
+        self.virt_read_i32(transport)
+    }
+
+    fn read_i64<T: Transport>(&mut self, transport: &mut T) -> Result<i64> {
+        self.virt_read_i64(transport)
+    }
+
+    fn read_double<T: Transport>(&mut self, transport: &mut T) -> Result<f64> {
+        self.virt_read_double(transport)
+    }
+
+    fn read_string<T: Transport>(&mut self, transport: &mut T) -> Result<String> {
+        self.virt_read_string(transport)
+    }
+
+    fn read_binary<T: Transport>(&mut self, transport: &mut T) -> Result<Vec<u8>> {
+        self.virt_read_binary(transport)
+    }
+
+    fn skip<T: Transport>(&mut self, transport: &mut T, type_: Type) -> Result<()> {
+        self.virt_skip(transport, type_)
+    }
+}
+
+fn _test_virt_impls() {
+    fn _is_encode<E: Encode + ?Sized>() {}
+    fn _is_protocol<P: Protocol + ?Sized>() {}
+    fn _is_transport<T: Transport + ?Sized>() {}
+
+    _is_transport::<&mut Transport>();
+    _is_protocol::<&mut VirtualProtocolObject>();
+    _is_encode::<&VirtualEncodeObject>();
+}
+

--- a/tutorial/rs/Cargo.toml
+++ b/tutorial/rs/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/server.rs"
 name = "benchmark"
 path = "src/benchmark.rs"
 
+[[bin]]
+name = "proxy"
+path = "src/proxy.rs"
+
 [dependencies]
 bufstream = "0.1"
 

--- a/tutorial/rs/src/benchmark.rs
+++ b/tutorial/rs/src/benchmark.rs
@@ -24,6 +24,7 @@ extern crate bufstream;
 use std::net::TcpStream;
 use bufstream::BufStream;
 use thrift::protocol::binary_protocol::BinaryProtocol;
+use thrift::transport::RwTransport;
 use tutorial::CalculatorClient;
 
 mod tutorial;
@@ -43,7 +44,7 @@ pub fn main() {
     };
 
     let mut client = tutorial::CalculatorClient::new(
-        BinaryProtocol, BufStream::new(TcpStream::connect("127.0.0.1:9090").unwrap()));
+        BinaryProtocol, RwTransport(BufStream::new(TcpStream::connect("127.0.0.1:9090").unwrap())));
 
     println!("Rust Thrift benchmark");
     println!("Running {} iterations", iterations);

--- a/tutorial/rs/src/bufferserver.rs
+++ b/tutorial/rs/src/bufferserver.rs
@@ -1,0 +1,18 @@
+use thrift::transport::server::TransportServer;
+use thrift::transport::RwTransport;
+
+use bufstream::BufStream;
+
+use std::net::{TcpListener, TcpStream};
+use std::io;
+
+pub struct BufferServer(pub TcpListener);
+
+impl TransportServer for BufferServer {
+     type Transport = RwTransport<BufStream<TcpStream>>;
+
+     fn accept(&self) -> io::Result<Self::Transport> {
+        self.0.accept().map(|res| RwTransport(BufStream::new(res.0)))
+     }
+}
+

--- a/tutorial/rs/src/client.rs
+++ b/tutorial/rs/src/client.rs
@@ -24,12 +24,13 @@ extern crate bufstream;
 use std::net::TcpStream;
 use bufstream::BufStream;
 use thrift::protocol::binary_protocol::BinaryProtocol;
+use thrift::transport::RwTransport;
 
 mod tutorial;
 mod shared;
 
 pub fn main() {
-    let stream = BufStream::new(TcpStream::connect("127.0.0.1:9090").unwrap());
+    let stream = RwTransport(BufStream::new(TcpStream::connect("127.0.0.1:9090").unwrap()));
     let mut client = tutorial::CalculatorClient::new(BinaryProtocol, stream);
 
     // Ping

--- a/tutorial/rs/src/proxy.rs
+++ b/tutorial/rs/src/proxy.rs
@@ -1,0 +1,121 @@
+#[macro_use]
+extern crate terminal_thrift as thrift;
+extern crate bufstream;
+
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc;
+use std::thread;
+
+use thrift::protocol::binary_protocol::BinaryProtocol;
+use thrift::transport::server::TransportServer;
+use thrift::processor::Processor;
+use thrift::protocol::ProtocolFactory;
+use thrift::proxy::SimpleProxy;
+use thrift::transport::RwTransport;
+
+use bufferserver::BufferServer;
+use bufstream::BufStream;
+
+use shared::*;
+
+mod bufferserver;
+mod shared;
+
+#[derive(Clone)]
+struct Handler {
+    sender: mpsc::Sender<i32>
+}
+
+impl SharedService for Handler {
+    fn getStruct(&self, id: i32) -> SharedStruct {
+        self.sender.send(id).unwrap();
+
+        SharedStruct { key: id, value: String::new() }
+    }
+}
+
+struct LimitedServer<P, PF, TS> {
+    limit: i32,
+    processor: P,
+    protocols: PF,
+    transports: TS
+}
+
+impl<P, PF, TS> LimitedServer<P, PF, TS>
+where P: Processor<PF::Protocol, TS::Transport>,
+      PF: ProtocolFactory, TS: TransportServer {
+    fn serve(&mut self) {
+        'serve: loop {
+            let mut transport = self.transports.accept().unwrap();
+            let mut protocol = self.protocols.new_protocol();
+
+            while let Ok(_) = self.processor.process(&mut protocol, &mut transport) {
+                self.limit -= 1;
+                if self.limit == 0 { break 'serve; }
+            }
+        }
+    }
+}
+
+fn main() {
+    let requests = 5;
+    let proxy_addr = "127.0.0.1:8001";
+    let receiver_addr = "127.0.0.1:8002";
+
+    let (source_tx, source_rx) = mpsc::channel();
+    let (receiver_tx, receiver_rx) = mpsc::channel();
+
+    let server_guard = thread::spawn(move || {
+        let source = Handler { sender: source_tx };
+        let receiver = Handler { sender: receiver_tx };
+
+        let mut source_processor = SharedServiceProcessor::new(source);
+        source_processor.proxy(SimpleProxy::new(|| BinaryProtocol,
+                                                move || Ok(RwTransport(try!(TcpStream::connect(receiver_addr))))));
+
+        let mut proxy_server = LimitedServer {
+            limit: requests,
+            processor: source_processor,
+            protocols: || BinaryProtocol,
+            transports: BufferServer(TcpListener::bind(proxy_addr).unwrap())
+        };
+
+        let mut receiver_server = LimitedServer {
+            limit: requests,
+            processor: SharedServiceProcessor::new(receiver),
+            protocols: || BinaryProtocol,
+            transports: BufferServer(TcpListener::bind(receiver_addr).unwrap())
+        };
+
+        let receiver_server_guard = thread::spawn(move || { receiver_server.serve(); receiver_server });
+        let proxy_server_guard = thread::spawn(move || { proxy_server.serve(); proxy_server });
+
+        receiver_server_guard.join().unwrap();
+        proxy_server_guard.join().unwrap();
+    });
+
+    // Very slightly racy so just sleep a bit to let the server start before sending requests.
+    thread::sleep_ms(100);
+
+    let client_guard = thread::spawn(move || {
+        let stream = RwTransport(BufStream::new(TcpStream::connect(proxy_addr).unwrap()));
+        let mut client = SharedServiceClient::new(BinaryProtocol, stream);
+
+        for i in 0..requests {
+            client.getStruct(i).unwrap();
+        }
+    });
+
+    client_guard.join().unwrap();
+    server_guard.join().unwrap();
+
+    let source_record = source_rx.iter().collect::<Vec<_>>();
+    let receiver_record = receiver_rx.iter().collect::<Vec<_>>();
+
+    assert_eq!(source_record.len() as i32, requests);
+    assert_eq!(receiver_record.len() as i32, requests);
+    assert_eq!(source_record, receiver_record);
+
+    println!("Passed!");
+}
+

--- a/tutorial/rs/src/server.rs
+++ b/tutorial/rs/src/server.rs
@@ -24,20 +24,19 @@ extern crate bufstream;
 mod tutorial;
 mod shared;
 
-use std::io;
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpListener;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
 use thrift::protocol::binary_protocol::BinaryProtocol;
 use thrift::server::SimpleServer;
-use thrift::transport::server::TransportServer;
-use thrift::transport::RwTransport;
 
 use tutorial::*;
 use shared::*;
 
-use bufstream::BufStream;
+use bufferserver::BufferServer;
+
+mod bufferserver;
 
 struct CalculatorHandler {
     log: RefCell<HashMap<i32, SharedStruct>>
@@ -91,16 +90,6 @@ impl<'a> SharedService for &'a CalculatorHandler {
         println!("getStruct({})", log_id);
         self.log.borrow()[&log_id].clone()
     }
-}
-
-struct BufferServer(TcpListener);
-
-impl TransportServer for BufferServer {
-     type Transport = RwTransport<BufStream<TcpStream>>;
-
-     fn accept(&self) -> io::Result<Self::Transport> {
-        self.0.accept().map(|res| RwTransport(BufStream::new(res.0)))
-     }
 }
 
 pub fn main() {

--- a/tutorial/rs/src/server.rs
+++ b/tutorial/rs/src/server.rs
@@ -32,6 +32,7 @@ use std::collections::HashMap;
 use thrift::protocol::binary_protocol::BinaryProtocol;
 use thrift::server::SimpleServer;
 use thrift::transport::server::TransportServer;
+use thrift::transport::RwTransport;
 
 use tutorial::*;
 use shared::*;
@@ -95,10 +96,10 @@ impl<'a> SharedService for &'a CalculatorHandler {
 struct BufferServer(TcpListener);
 
 impl TransportServer for BufferServer {
-     type Transport = BufStream<TcpStream>;
+     type Transport = RwTransport<BufStream<TcpStream>>;
 
-     fn accept(&self) -> io::Result<BufStream<TcpStream>> {
-        self.0.accept().map(|res| BufStream::new(res.0))
+     fn accept(&self) -> io::Result<Self::Transport> {
+        self.0.accept().map(|res| RwTransport(BufStream::new(res.0)))
      }
 }
 


### PR DESCRIPTION
Add a new concept to the rust thrift implementation: Proxies. Proxies allow you to intercept and replay RPC calls as they come in through the Processor, this can be used for all sorts of interesting things, such as logging, actual proxying, building a consistent log of all write actions, etc. 

Proxies are implemented through a rather annoying set of alternate traits which are all object safe, but this is mostly hidden from the user, all they must do is impl `for<E: Encode> Proxy<E>`, and everything should work just fine.

There is an example in `tutorial/rs/src/proxy.rs` which compiles and runs without error.

No changes were necessary to the C++ generator to implement this feature.
